### PR TITLE
Remove undecodable bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,6 @@ api.servers[0].restore_zone(zone_file)
 
 MIT LICENSE *(see LICENSE file)*
 
-## Miscellaneous
-
-```
-    ╚⊙ ⊙╝
-  ╚═(███)═╝
- ╚═(███)═╝
-╚═(███)═╝
- ╚═(███)═╝
-  ╚═(███)═╝
-   ╚═(███)═╝
-```
 
 [1]: https://img.shields.io/badge/python-2.7,3.4+-blue.svg
 [1l]: https://github.com/outini/python-powerdns


### PR DESCRIPTION
The bug in the readme is not ASCII decodable causes the package to be non-downloadable on certain OS. e.g. on cenos7: `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 4053: ordinal not in range(128)`