### PR TITLE
adds an ignored directory for private scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/*
 dist/*
 python_powerdns.egg-info/*
+*.pyc
+private_bin


### PR DESCRIPTION
This directory is useful to store tests scripts or scripts that are not
meant to be publicly released.