### PR TITLE
Fix suggest zone to make sure the zone name is a dns component

### DIFF
--- a/powerdns/interface.py
+++ b/powerdns/interface.py
@@ -238,7 +238,7 @@ class PDNSServer(PDNSEndpointBase):
             raise PDNSCanonicalError(r_name)
         best_match = None
         for zone in self.zones:
-            if r_name.endswith(zone.name):
+            if r_name.endswith('.' + zone.name):
                 if not best_match:
                     best_match = zone
                 if best_match and len(zone.name) > len(best_match.name):


### PR DESCRIPTION
Need to include '.' before the name to keep from picking a zone based
on the end of the hostname that isn't the subdomain.

This fixes #30 